### PR TITLE
Log_hour & Return Added

### DIFF
--- a/lib/boat.rb
+++ b/lib/boat.rb
@@ -1,5 +1,6 @@
 class Boat
   attr_reader :type, :price_per_hour, :hours_rented
+  attr_writer :hours_rented
 
   def initialize(type, price_per_hour)
     @type = type

--- a/lib/boat.rb
+++ b/lib/boat.rb
@@ -1,0 +1,14 @@
+class Boat
+  attr_reader :type, :price_per_hour, :hours_rented
+
+  def initialize(type, price_per_hour)
+    @type = type
+    @price_per_hour = price_per_hour
+    @hours_rented = 0
+  end
+
+  def add_hour
+    @hours_rented += 1
+  end
+
+end

--- a/lib/dock.rb
+++ b/lib/dock.rb
@@ -1,9 +1,26 @@
 class Dock
-  attr_reader :name, :max_rental_time
+  attr_reader :name, :max_rental_time, :rental_log
 
   def initialize(name, max_rental_time)
     @name = name
     @max_rental_time = max_rental_time
+    @rental_log = {}
+  end
+
+  def rent(boat,renter)
+    @rental_log[boat] = renter
+  end
+
+  def charge(boat)
+    charge_hash = {
+      :credit_card_number => @rental_log[boat].credit_card_number,
+      :amount =>
+      if boat.hours_rented <= max_rental_time
+        boat.hours_rented * boat.price_per_hour
+      else
+        boat.price_per_hour * max_rental_time
+      end
+    }
   end
 
 end

--- a/lib/dock.rb
+++ b/lib/dock.rb
@@ -1,0 +1,9 @@
+class Dock
+  attr_reader :name, :max_rental_time
+
+  def initialize(name, max_rental_time)
+    @name = name
+    @max_rental_time = max_rental_time
+  end
+
+end

--- a/lib/dock.rb
+++ b/lib/dock.rb
@@ -1,10 +1,11 @@
 class Dock
-  attr_reader :name, :max_rental_time, :rental_log
+  attr_reader :name, :max_rental_time, :rental_log, :revenue
 
   def initialize(name, max_rental_time)
     @name = name
     @max_rental_time = max_rental_time
     @rental_log = {}
+    @revenue = 0
   end
 
   def rent(boat,renter)
@@ -21,6 +22,21 @@ class Dock
         boat.price_per_hour * max_rental_time
       end
     }
+  end
+
+  def log_hour
+    @rental_log.each do |boat, renter|
+      boat.hours_rented += 1
+    end
+  end
+
+  def return(boat)
+    if boat.hours_rented <= max_rental_time
+      @revenue += (boat.hours_rented * boat.price_per_hour)
+    else
+      @revenue += (boat.price_per_hour * max_rental_time)
+    end
+    @rental_log.delete(boat)
   end
 
 end

--- a/lib/renter.rb
+++ b/lib/renter.rb
@@ -1,0 +1,9 @@
+class Renter
+  attr_reader :name, :credit_card_number
+
+  def initialize(name, credit_card_number)
+    @name = name
+    @credit_card_number = credit_card_number
+  end
+
+end

--- a/spec/boat_spec.rb
+++ b/spec/boat_spec.rb
@@ -1,0 +1,20 @@
+require './lib/boat'
+
+RSpec.describe Boat do
+
+  it "has readable attributes" do
+    kayak = Boat.new(:kayak, 20)
+    expect(kayak.type).to eq(:kayak)
+    expect(kayak.price_per_hour).to eq(20)
+  end
+
+  it "can add hours to hours_rented" do
+    kayak = Boat.new(:kayak, 20)
+    expect(kayak.hours_rented).to eq(0)
+    kayak.add_hour
+    kayak.add_hour
+    kayak.add_hour
+    expect(kayak.hours_rented).to eq(3)
+  end
+
+end

--- a/spec/dock_spec.rb
+++ b/spec/dock_spec.rb
@@ -10,4 +10,55 @@ RSpec.describe Dock do
     expect(dock.max_rental_time).to eq(3)
   end
 
+  it "can rent a boat to a renter" do
+    dock = Dock.new("The Rowing Dock", 3)
+    kayak_1 = Boat.new(:kayak, 20)
+    kayak_2 = Boat.new(:kayak, 20)
+    sup_1 = Boat.new(:standup_paddle_board, 15)
+    patrick = Renter.new("Patrick Star", "4242424242424242")
+    eugene = Renter.new("Eugene Crabs", "1313131313131313")
+    dock.rent(kayak_1, patrick)
+    dock.rent(kayak_2, patrick)
+    dock.rent(sup_1, eugene)
+    expect(dock.rental_log.count).to eq(3)
+    expected = {
+      kayak_1 => patrick,
+      kayak_2 => patrick,
+      sup_1 => eugene
+    }
+    expect(dock.rental_log).to eq(expected)
+    # require 'pry';binding.pry
+  end
+
+  it "can charge a renter for a boat" do
+    dock = Dock.new("The Rowing Dock", 3)
+    kayak_1 = Boat.new(:kayak, 20)
+    kayak_2 = Boat.new(:kayak, 20)
+    sup_1 = Boat.new(:standup_paddle_board, 15)
+    patrick = Renter.new("Patrick Star", "4242424242424242")
+    eugene = Renter.new("Eugene Crabs", "1313131313131313")
+    dock.rent(kayak_1, patrick)
+    dock.rent(kayak_2, patrick)
+    dock.rent(sup_1, eugene)
+    kayak_1.add_hour
+    kayak_1.add_hour
+    expected = {
+      :credit_card_number => "4242424242424242",
+      :amount => 40
+    }
+    expect(dock.charge(kayak_1)).to eq(expected)
+    sup_1.add_hour
+    sup_1.add_hour
+    sup_1.add_hour
+    sup_1.add_hour
+    sup_1.add_hour
+    expected2 = {
+      :credit_card_number => "1313131313131313",
+      :amount => 45
+    }
+    expect(dock.charge(sup_1)).to eq(expected2)
+    require 'pry';binding.pry
+
+  end
+
 end

--- a/spec/dock_spec.rb
+++ b/spec/dock_spec.rb
@@ -1,0 +1,13 @@
+require './lib/dock'
+require './lib/renter'
+require './lib/boat'
+
+RSpec.describe Dock do
+
+  it "has readable attributes" do
+    dock = Dock.new("The Rowing Dock", 3)
+    expect(dock.name).to eq("The Rowing Dock")
+    expect(dock.max_rental_time).to eq(3)
+  end
+
+end

--- a/spec/dock_spec.rb
+++ b/spec/dock_spec.rb
@@ -57,8 +57,41 @@ RSpec.describe Dock do
       :amount => 45
     }
     expect(dock.charge(sup_1)).to eq(expected2)
-    require 'pry';binding.pry
-
   end
 
+  it "can log hours to all boats at once and return boats" do
+    dock = Dock.new("The Rowing Dock", 3)
+    kayak_1 = Boat.new(:kayak, 20)
+    kayak_2 = Boat.new(:kayak, 20)
+    canoe = Boat.new(:canoe, 25)
+    sup_1 = Boat.new(:standup_paddle_board, 15)
+    sup_2 = Boat.new(:standup_paddle_board, 15)
+    patrick = Renter.new("Patrick Star", "4242424242424242")
+    eugene = Renter.new("Eugene Crabs", "1313131313131313")
+    dock.rent(kayak_1, patrick)
+    dock.rent(kayak_2, patrick)
+    dock.log_hour
+    expect(kayak_1.hours_rented).to eq(1)
+    expect(kayak_2.hours_rented).to eq(1)
+    dock.rent(canoe, patrick)
+    dock.log_hour
+    expect(kayak_1.hours_rented).to eq(2)
+    expect(kayak_2.hours_rented).to eq(2)
+    expect(canoe.hours_rented).to eq(1)
+    expect(dock.revenue).to eq(0)
+    dock.return(kayak_1)
+    dock.return(kayak_2)
+    dock.return(canoe)
+    expect(dock.revenue).to eq(105)
+    expect(dock.rental_log).to eq({})
+    dock.rent(sup_1, eugene)
+    dock.rent(sup_2, eugene)
+    5.times do
+      dock.log_hour
+    end
+    dock.return(sup_1)
+    dock.return(sup_2)
+    expect(dock.revenue).to eq(195)
+    expect(dock.rental_log).to eq({})
+  end
 end

--- a/spec/renter_spec.rb
+++ b/spec/renter_spec.rb
@@ -1,0 +1,11 @@
+require './lib/renter'
+
+RSpec.describe Renter do
+
+  it "has readable attributes" do
+    renter = Renter.new("Patrick Star", "4242424242424242")
+    expect(renter.name).to eq("Patrick Star")
+    expect(renter.credit_card_number).to eq("4242424242424242")
+  end
+
+end


### PR DESCRIPTION
What does this PR do?

Added method to log hour to all boats currently rented, and ability to "return" a boat which removes it from the rental log, and charges the correct amount of revenue to the dock in which it is associated with

